### PR TITLE
Fix numpy inhomogeneous shape error

### DIFF
--- a/source/CorotationalBeamElement3D.py
+++ b/source/CorotationalBeamElement3D.py
@@ -797,9 +797,9 @@ class CorotationalBeamElement3D():
         q_1, q_2, q = self.auxiliary_vector()
         R_g = self.current_local_frame()
 
-        q1, q2 = (R_g.T @ q)[0: 2]
-        q11, q12 = (R_g.T @ q_1)[0: 2]
-        q21, q22 = (R_g.T @ q_2)[0: 2]
+        q1, q2 = (R_g.T @ q)[0: 2, 0]
+        q11, q12 = (R_g.T @ q_1)[0: 2, 0]
+        q21, q22 = (R_g.T @ q_2)[0: 2, 0]
 
         eta = q1 / q2
         eta_11 = q11 / q2

--- a/source/Utilities.py
+++ b/source/Utilities.py
@@ -100,9 +100,9 @@ def get_skew_symmetric(rotational_vector):
         the skew symmetric matrix of the rotational vector.
 
     """
-    skew_symmetric = np.array([[0.0, -rotational_vector[2], rotational_vector[1]],
-                               [rotational_vector[2], 0.0, -rotational_vector[0]],
-                               [-rotational_vector[1], rotational_vector[0], 0.0]], dtype=float)
+    skew_symmetric = np.array([[0.0, -rotational_vector[2,0], rotational_vector[1,0]],
+                               [rotational_vector[2,0], 0.0, -rotational_vector[0,0]],
+                               [-rotational_vector[1,0], rotational_vector[0,0], 0.0]], dtype=float)
     return skew_symmetric
 
 


### PR DESCRIPTION
Fixes some numpy shape related errors when running 3D examples.

Tested on:

Python 3.10.0
Numpy 1.26.4